### PR TITLE
Enable downloading of the same artifact to the same machine multiple times

### DIFF
--- a/manifests/artifact.pp
+++ b/manifests/artifact.pp
@@ -78,17 +78,17 @@ define artifactory::artifact(
   $cmd = "/opt/artifactory-script/download-artifact-from-artifactory.sh -a ${gav} -e ${packaging} ${includeClass} -n ${artifactory::ARTIFACTORY_URL} ${includeRepo} ${timestampedRepo} -o ${output} ${args} -v"
 
   if $ensure == present {
-    exec { "Download ${gav}-${classifier}":
+    exec { "Download ${gav}-${classifier} to ${output}":
       command => $cmd,
       unless  => "test -f ${output}"
     }
   } elsif $ensure == absent {
-    file { "Remove ${gav}-${classifier}":
+    file { "Remove ${gav}-${classifier} to ${output}":
       path   => $output,
       ensure => absent
     }
   } else {
-    exec { "Download ${gav}-${classifier}":
+    exec { "Download ${gav}-${classifier} to ${output}":
       command => $cmd,
     }
   }


### PR DESCRIPTION
This allows downloading of the same artifact to different folders on the same machine. Without the output folder catalog compilation will fail due to a duplicate Exec definition.
