### PR TITLE
Implement setting artifactory context

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'jcraigbrown-artifactory'
-version '0.0.4'
+version '0.0.5'
 source 'https://github.com/jcraigbrown/artifactory.git'
 author 'J. Craig Brown'
 license 'Apache License, Version 2.0'

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Usage
 	# Initialize the Puppet Artifactory module
 	class {'artifactory':
 	  url => 'http://artifactory.domain.com',
+      context => '/artifactory'
+	}
+	
+    class {'proxied-artifactory':
+	  url => 'http://artifactory.domain.com',
+      context => '/'
 	}
 
 	artifactory::artifact {'commons-io':

--- a/files/download-artifact-from-artifactory.sh
+++ b/files/download-artifact-from-artifactory.sh
@@ -2,7 +2,7 @@
 
 # Define Artifactory Configuration
 ARTIFACTORY_BASE=
-URL_BASE=/artifactory
+URL_BASE=
 
 usage()
 {
@@ -108,7 +108,7 @@ TIMESTAMPED_SNAPSHOT=0
 
 OUTPUT=
 
-while getopts "hvta:c:e:o:r:u:p:n:" OPTION
+while getopts "hvta:c:e:o:r:u:p:n:b:" OPTION
 do
     case $OPTION in
         h)
@@ -150,6 +150,9 @@ do
             ;;
         n)
             ARTIFACTORY_BASE=$OPTARG
+            ;;
+        b)
+            URL_BASE=$OPTARG
             ;;
         ?)
             echo "Illegal argument $OPTION=$OPTARG" >&2

--- a/manifests/artifact.pp
+++ b/manifests/artifact.pp
@@ -75,7 +75,9 @@ define artifactory::artifact(
     $timestampedRepo = "-t"
   }
 
-  $cmd = "/opt/artifactory-script/download-artifact-from-artifactory.sh -a ${gav} -e ${packaging} ${includeClass} -n ${artifactory::ARTIFACTORY_URL} ${includeRepo} ${timestampedRepo} -o ${output} ${args} -v"
+  $baseUrl = "-b ${artifactory::ARTIFACTORY_CONTEXT}"
+
+  $cmd = "/opt/artifactory-script/download-artifact-from-artifactory.sh -a ${gav} -e ${packaging} ${includeClass} -n ${artifactory::ARTIFACTORY_URL} ${baseUrl} ${includeRepo} ${timestampedRepo} -o ${output} ${args} -v"
 
   if $ensure == present {
     exec { "Download ${gav}-${classifier} to ${output}":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@
 #
 # Parameters:
 # [*url*] : The Artifactory base url (mandatory)
+# [*context*] : Artifactory context, defaults to /artifactory
 # [*username*] : The username used to connect to artifactory
 # [*password*] : The password used to connect to artifactory
 #
@@ -19,6 +20,7 @@
 #
 class artifactory(
   $url = '',
+  $context = '/artifactory',
   $username = '',
   $password = '')
 {
@@ -29,6 +31,7 @@ class artifactory(
     fail('Cannot initialize the Artifactory class - the url parameter is mandatory')
   }
   $ARTIFACTORY_URL = $url
+  $ARTIFACTORY_CONTEXT = $context
 
   if ($username != '') and ($password == '') {
     fail('Cannot initialize the Artifactory class - both username and password must be set')


### PR DESCRIPTION
Artifactory installation context can now be set with the context
parameter to the artifactory class. This is useful if the context is
something else than /artifactory (default).
