### PR TITLE
Add windows support and MD5 checksum verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Puppet Module for Artifactory
 A Puppet module which downloads artifacts from an Artifactory repository.
 
 It supports:
+
 * artifact identification using GAV, classifier, and packaging
 * repository selection
-* timestamped SNAPSHOTs
+* timestamped SNAPSHOTs (not on Windows)
 
 It relies on the Artifactory REST service, bash, and curl.
 
@@ -25,10 +26,16 @@ Getting the Module
 Usage
 -----
 
-	# Initialize the Puppet Artifactory module
+Initialize the Puppet Artifactory module and specify the URL of your artifactory
+system. Note that previous versions of this module automatically appended
+'/artifactory' to this URL. This is no longer the case, so make sure the
+specified URL includes '/artifactory', if required.
+
 	class {'artifactory':
 	  url => 'http://artifactory.domain.com',
 	}
+
+Examples of downloading artifacts:
 
 	artifactory::artifact {'commons-io':
 	  gav        => 'commons-io:commons-io:2.1',

--- a/files/compare-artifact-checksums.ps1
+++ b/files/compare-artifact-checksums.ps1
@@ -1,0 +1,142 @@
+﻿<#
+.SYNOPSIS
+    Compare a file on the file system with a file (an artifact) in Artifactory.
+    The comparison is done with MD5 checksums.
+
+    The script will return with exit code 0 if the file on the file system
+    has the same MD5 checksum as in Artifatory.
+
+    The script will return with exit code 1 if the MD5 checksums differ or
+    if an error occurred.
+    
+.DESCRIPTION
+   download-artifact-from-artifactory.ps1 [-h]
+   download-artifact-from-artifactory.ps1 [-v] [-t] -a <groupId:artifactId:version> [-c <classifier>] [-e <packaging>] [-o <outfile>] [-r <repository>] [-u <username>] [-p password] [-n <baseURL>]
+#>
+
+
+param(
+    [switch]$help,
+    [switch]$verbose,
+    [switch]$timestamped_snapshot, 
+    [string]$artifactGAV,
+    [string]$classifier,
+    [string]$e_packaging='jar',
+    [string]$output,
+    [string]$repo,
+    [string]$username,
+    [string]$password,
+    [string]$n_baseurl
+)
+
+function md5sum {
+    param ( $_filename )
+ 
+    $algo   = [System.Security.Cryptography.HashAlgorithm]::Create("MD5")
+    $stream = New-Object System.IO.FileStream($_filename, [System.IO.FileMode]::Open)
+ 
+    [string]$sum = -join ($algo.ComputeHash($stream) | % { "{0:x2}" -f $_ } )
+ 
+    $stream.Dispose()
+
+    return $sum
+}
+
+
+if ($help) {
+    get-help $MyInvocation.MyCommand.Definition
+    exit 0
+}
+
+if ($verbose) {
+    $VerbosePreference = "Continue"
+    $curl_verbose='-v'
+}
+
+($groupid, $artifactid, $version) = $artifactGAV.split(':')
+$groupid = $groupid.Replace('.','/')
+
+if (!$groupid -or !$artifactid -or !$version) {
+    write-error "BAD ARGUMENTS: Either groupId, artifactId, or version was not supplied"
+    get-help $MyInvocation.MyCommand.Definition
+    exit 1
+}
+
+if (!$repo) {
+    if ($version -match "snapshot") {
+        $repo = "snapshots"
+    } else {
+        $repo = "releases"
+    }
+}
+
+# Construct the base URL
+$artifact_api_base_url = "${n_baseurl}/api/storage/${repo}/${groupid}/${artifactid}/${version}"
+$artifact_base_url     = "${n_baseurl}/${repo}/${groupid}/${artifactid}/${version}"
+
+if ($classifier) {
+    $artifact_target_name = "${artifactid}-${version}-${classifier}.${e_packaging}"
+} else {
+    $artifact_target_name = "${artifactid}-${version}.${e_packaging}"
+}
+
+if ("${version}" -match "snapshot" -and ${timestamped_snapshot}) {
+    # TODO: Add support for timestamped snapshot
+    write-error "Option 'timestamped_snapshot' was specified, but this module does not yet support that feature on Windows"
+    exit 1
+} else {
+    $artifact_source_name=${artifact_target_name}
+}
+
+if ($username -and $password) {
+    # TODO: Add support for authentication
+    write-error "Username and password was specified, but this module does not yet support that feature on Windows"
+    exit 1
+}
+
+$fileinfo_request_url = "${artifact_api_base_url}/${artifact_source_name}"
+
+if ($output) {
+    $localfile = "$output"
+} else {
+    $localfile = "${artifact_target_name}"
+}
+
+write-verbose  "Base API URL:         ${artifact_api_base_url}"
+write-verbose  "Artifact Target:      ${artifact_target_name}"
+write-verbose  "Artifact Source:      ${artifact_source_name}"
+write-verbose  "Fileinfo request URL: ${fileinfo_request_url}"
+write-verbose  "Local file:           ${localfile}"
+
+
+try {
+    # This will disable ssl certificate check, which is generally dangerous, but useful
+    # if your artifactory server is on https with a self-signed certificate.
+    [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
+
+    $wc = New-Object System.Net.WebClient
+    $md5_checksum_repo = ($wc.DownloadString("${fileinfo_request_url}") | ConvertFrom-Json).checksums.md5
+
+}
+catch {
+    write-error ("Fetching checksum FAILED! An exception occured while trying to fetch:`n" + $_.Exception.ToString())
+    exit 1
+}
+finally {
+    # Restore default ssl security settings
+    [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {}
+}
+
+
+$md5_checksum_file = md5sum $localfile
+write-verbose "Comparing checksums:"
+write-verbose "from repo: ${md5_checksum_repo}"
+write-verbose "from file: ${md5_checksum_file}"
+
+if ( "$md5_checksum_repo" -eq "$md5_checksum_file" ) {
+    write-verbose "Checksums from repository and local file are identical"
+    exit 0
+} else {
+    write-verbose "Checksum from repository: ""${md5_checksum_repo}"" differ from checksum of local file: ""${md5_checksum_file}"""
+    exit 1
+}

--- a/files/compare-artifact-checksums.sh
+++ b/files/compare-artifact-checksums.sh
@@ -1,0 +1,259 @@
+#!/bin/bash
+
+# Define Artifactory Configuration
+ARTIFACTORY_BASE=
+URL_BASE=
+
+usage()
+{
+    cat <<EOF
+
+usage: $0 options
+
+This script will check if the desired artifact file
+exists locally and has the same checksum as in Artifactory. 
+
+OPTIONS:
+   -h    Show this message
+   -v    Verbose
+   -t    Timestamped SNAPSHOTs
+   -a    GAV coordinate groupId:artifactId:version
+   -c    Artifact Classifier
+   -e    Artifact Packaging
+   -o    Output file
+   -r    Repository
+   -u    Username
+   -p    Password
+   -n    Artifactory Base URL
+
+EOF
+}
+
+function artifact_target_name()
+{
+    local __artifact=$1
+    local __version=$2
+    local __packaging=$3
+    local __classifier=$4
+    local __target="${__artifact}-${__version}"
+
+    if [[ ${__classifier} != "" ]]
+    then
+        __target="${__target}-${__classifier}"
+    fi
+    __target="${__target}.${__packaging}"
+
+    echo "${__target}"
+}
+
+function artifact_source_name()
+{
+    local __artifact_base_url=$1
+    local __artifact=$2
+    local __snapshot=$3
+    local __packaging=$4
+    local __classifier=$5
+
+    # Strip -SNAPSHOT from version
+    local __version=`echo ${__snapshot} | sed -e "s/-SNAPSHOT//"`
+    local __source="${__artifact}-${__version}"
+
+    get_timestamp_and_build timestamp build ${__artifact_base_url}
+    __source="${__source}-${timestamp}-${build}"
+
+    if [[ ${__classifier} != "" ]]
+    then
+        __source="${__source}-${__classifier}"
+    fi
+    __source="${__source}.${__packaging}"
+
+    echo "${__source}"
+}
+
+# Extract timestamp and build from maven-metadata.xml
+function get_timestamp_and_build()
+{
+    local __timestamp_result=$1
+    local __build_result=$2
+    local __request_url=$3/maven-metadata.xml
+    local __maven_metadata="/tmp/maven-metadata-$$.xml"
+    local __ts=
+    local __build=
+
+    # Retrieve the maven-metadata.xml file
+    curl -sS -f -L ${__request_url} -o ${__maven_metadata} ${CURL_VERBOSE} --location-trusted
+    # Command to extract the timestamp
+    __ts=`cat ${__maven_metadata} | tr -d [:space:] | grep -o "<timestamp>.*</timestamp>" \
+        | tr '<>' '  ' | awk '{ print $2 }'`
+    # Command to extract the build number
+    __build=`cat ${__maven_metadata} | tr -d [:space:] | grep -o "<buildNumber>.*</buildNumber>" \
+        | tr '<>' '  ' | awk '{ print $2 }'`
+    # Remove the maven-metadata.xml file
+    #rm ${__maven_metadata}
+
+    eval ${__timestamp_result}="'${__ts}'"
+    eval ${__build_result}="'${__build}'"
+}
+
+# Read in Complete Set of Coordinates from the Command Line
+GROUP_ID=
+ARTIFACT_ID=
+VERSION=
+CLASSIFIER=""
+PACKAGING=jar
+REPO=
+USERNAME=
+PASSWORD=
+VERBOSE=0
+TIMESTAMPED_SNAPSHOT=0
+
+OUTPUT=
+
+while getopts "hvta:c:e:o:r:u:p:n:" OPTION
+do
+    case $OPTION in
+        h)
+            usage
+            exit 1
+            ;;
+        a)
+            OIFS=$IFS
+            IFS=":"
+            GAV_COORD=( $OPTARG )
+            GROUP_ID=`echo ${GAV_COORD[0]} | tr . /`
+            ARTIFACT_ID=${GAV_COORD[1]}
+            VERSION=${GAV_COORD[2]}         
+            IFS=$OIFS
+            ;;
+        c)
+            CLASSIFIER=$OPTARG
+            ;;
+        e)
+            PACKAGING=$OPTARG
+            ;;
+        v)
+            VERBOSE=1
+            ;;
+        t)
+            TIMESTAMPED_SNAPSHOT=1
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        r)
+            REPO=$OPTARG
+            ;;
+        u)
+            USERNAME=$OPTARG
+            ;;
+        p)
+            PASSWORD=$OPTARG
+            ;;
+        n)
+            ARTIFACTORY_BASE=$OPTARG
+            ;;
+        ?)
+            echo "Illegal argument $OPTION=$OPTARG" >&2
+            usage
+            exit
+            ;;
+    esac
+done
+
+if [[ ${VERBOSE} -eq 0 ]]
+then
+    CURL_VERBOSE=""
+else
+    CURL_VERBOSE="-v"
+fi
+
+if [[ -z $GROUP_ID ]] || [[ -z $ARTIFACT_ID ]] || [[ -z $VERSION ]]
+then
+    echo "BAD ARGUMENTS: Either groupId, artifactId, or version was not supplied" >&2
+    usage
+    exit 1
+fi
+
+# Define default values for optional components
+
+# If we don't have set a repository and the version requested is a SNAPSHOT use snapshots, otherwise use releases
+if [[ "$REPOSITORY" == "" ]]
+then
+    if [[ "$VERSION" =~ "SNAPSHOT" ]]
+    then
+        if [[ ${VERBOSE} -ne 0 ]]
+        then
+            echo "Setting REPO to snapshots"
+        fi
+        : ${REPO:="snapshots"}
+    else
+        if [[ ${VERBOSE} -ne 0 ]]
+        then
+            echo "Setting REPO to releases"
+        fi
+        : ${REPO:="releases"}
+    fi
+fi
+
+# Construct the base URL
+ARTIFACT_API_BASE_URL=${ARTIFACTORY_BASE}${URL_BASE}/api/storage/${REPO}/${GROUP_ID}/${ARTIFACT_ID}/${VERSION}
+ARTIFACT_TARGET_NAME=$( artifact_target_name ${ARTIFACT_ID} ${VERSION} ${PACKAGING} ${CLASSIFIER} )
+
+if [[ "${VERSION}" =~ "SNAPSHOT" ]] && [[ ${TIMESTAMPED_SNAPSHOT} -ne 0 ]]
+then
+    ARTIFACT_SOURCE_NAME=$( artifact_source_name ${ARTIFACT_API_BASE_URL} ${ARTIFACT_ID} ${VERSION} ${PACKAGING} ${CLASSIFIER} )
+else
+    ARTIFACT_SOURCE_NAME=${ARTIFACT_TARGET_NAME}
+fi
+
+if [[ ${VERBOSE} -ne 0 ]]
+then
+    echo "Base URL: ${ARTIFACT_API_BASE_URL}"
+    echo "Artifact Target: ${ARTIFACT_TARGET_NAME}"
+    echo "Artifact Source: ${ARTIFACT_SOURCE_NAME}"
+fi
+
+REQUEST_URL="${ARTIFACT_API_BASE_URL}/${ARTIFACT_SOURCE_NAME}"
+FILEINFO_REQUEST_URL="${ARTIFACT_API_BASE_URL}/${ARTIFACT_SOURCE_NAME}"
+
+# Authentication
+AUTHENTICATION=
+if [[ "$USERNAME" != "" ]]  && [[ "$PASSWORD" != "" ]]
+then
+    AUTHENTICATION="-u $USERNAME:$PASSWORD"
+fi
+
+# Output
+LOCALFILE=
+if [[ "$OUTPUT" != "" ]] 
+then
+    LOCALFILE="$OUTPUT"
+else
+    LOCALFILE="${ARTIFACT_TARGET_NAME}"
+fi
+
+# If the local file does not exist, there's no check to do so exit now
+if [[ ! -f $LOCALFILE ]]
+then
+  echo "File $LOCALFILE does not exist" >&2
+  exit 1
+fi
+ 
+echo "Fetching Artifact file info from $FILEINFO_REQUEST_URL..." >&2
+FILEINFO=$(curl -sS -f -L ${FILEINFO_REQUEST_URL} ${AUTHENTICATION} ${CURL_VERBOSE} --location-trusted)
+
+MD5_CHECKSUM_REPO=$(echo $FILEINFO | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["checksums"]["md5"]')
+MD5_CHECKSUM_FILE=$(md5sum $LOCALFILE | awk '{print $1}')
+
+echo "Comparing checksums:"
+echo "From repo: $MD5_CHECKSUM_REPO"
+echo "From file: $MD5_CHECKSUM_FILE"
+
+if [[ "$MD5_CHECKSUM_REPO" == "$MD5_CHECKSUM_FILE" ]]
+then
+  echo "Checksums from repository and local file are identical" >&2
+  exit 0
+else
+  echo "Checksum from repository: ""$MD5_CHECKSUM_REPO"" differ from checksum of local file: ""$MD5_CHECKSUM_FILE""" >&2
+  exit 1
+fi

--- a/files/download-artifact-from-artifactory.ps1
+++ b/files/download-artifact-from-artifactory.ps1
@@ -14,8 +14,7 @@
  
 .PARAMETER -n
         Base URL of artifactory.
-		Note: include '/artifactory' at the end, if artifactory is available under that location. (Earlier versions
-		of the puppet module always appended this. That is no longer the case).
+	Note: include '/artifactory' at the end, if artifactory is available under that location.
  
     
 .NOTES    
@@ -42,7 +41,7 @@ param(
     [string]$repo,
     [string]$username,
     [string]$password,
-	[string]$n_baseurl
+    [string]$n_baseurl
 )
 
 

--- a/files/download-artifact-from-artifactory.ps1
+++ b/files/download-artifact-from-artifactory.ps1
@@ -1,0 +1,125 @@
+<#
+.SYNOPSIS
+    Download artifact from Artifactory.
+    
+.DESCRIPTION
+   download-artifact-from-artifactory.ps1 [-h]
+   download-artifact-from-artifactory.ps1 [-v] [-t] -a <groupId:artifactId:version> [-c <classifier>] [-e <packaging>] [-o <outfile>] [-r <repository>] [-u <username>] [-p password] [-n <baseURL>]
+
+.PARAMETER -h
+        show help.
+        
+.PARAMETER -v
+        Verbose output.
+ 
+.PARAMETER -n
+        Base URL of artifactory.
+		Note: include '/artifactory' at the end, if artifactory is available under that location. (Earlier versions
+		of the puppet module always appended this. That is no longer the case).
+ 
+    
+.NOTES    
+    
+.EXAMPLE
+        
+        download-artifact-from-artifactory.ps1 -a ...
+    
+    Description
+    -----------
+    Downloads ....
+        
+#>
+
+
+param(
+    [switch]$help,
+    [switch]$verbose,
+    [switch]$timestamped_snapshot, 
+    [string]$artifactGAV,
+    [string]$classifier,
+    [string]$e_packaging='jar',
+    [string]$output,
+    [string]$repo,
+    [string]$username,
+    [string]$password,
+	[string]$n_baseurl
+)
+
+
+if ($help) {
+	get-help $MyInvocation.MyCommand.Definition
+    exit 0
+}
+
+if ($verbose) {
+    $VerbosePreference = "Continue"
+    $curl_verbose='-v'
+}
+
+($groupid, $artifactid, $version) = $artifactGAV.split(':')
+$groupid = $groupid.Replace('.','/')
+
+if (!$groupid -or !$artifactid -or !$version) {
+	write-error "BAD ARGUMENTS: Either groupId, artifactId, or version was not supplied"
+	get-help $MyInvocation.MyCommand.Definition
+    exit 1
+}
+
+if (!$repo) {
+    if ($version -match "snapshot") {
+		$repo = "snapshots"
+	} else {
+		$repo = "releases"
+	}
+}
+
+# Construct the base URL
+$artifact_base_url    = "${n_baseurl}/${repo}/${groupid}/${artifactid}/${version}"
+if ($classifier) {
+	$artifact_target_name = "${artifactid}-${version}-${classifier}.${e_packaging}"
+} else {
+	$artifact_target_name = "${artifactid}-${version}.${e_packaging}"
+}
+
+if ("${version}" -match "snapshot" -and ${timestamped_snapshot}) {
+    # TODO: support for timestamped snapshot
+    write-error "WARNING: Option 'timestamped_snapshot' was specified, but that feature is not yet supported in this script!"
+} else {
+    $artifact_source_name=${artifact_target_name}
+}
+
+if ($username -and $password) {
+	# TODO: support for authentication
+    write-error "WARNING: Username and password was specified, but authenticated access is not yet supported in this script!"
+}
+
+$request_url = "${artifact_base_url}/${artifact_source_name}"
+
+if ($output) {
+    $out = "$output"
+} else {
+    $out = "${artifact_target_name}"
+}
+
+write-verbose  "Base URL:        ${artifact_base_url}"
+write-verbose  "Artifact Target: ${artifact_target_name}"
+write-verbose  "Artifact Source: ${artifact_source_name}"
+write-verbose  "request URL:     ${request_url}"
+write-verbose  "Output file:     ${out}"
+
+try {
+	# This will disable ssl certificate check, which is generally dangerous, but useful
+	# if your artifactory server is on https with a self-signed certificate.
+	[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
+
+	$wc = New-Object System.Net.WebClient
+	$wc.DownloadFile("${request_url}", "$out")
+}
+catch {
+	write-error ("DOWNLOAD FAILED! An exception occured while trying to download:`n" + $_.Exception.ToString())
+	exit 1
+}
+finally {
+	# Restore default ssl security settings
+	[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {}
+}

--- a/files/download-artifact-from-artifactory.sh
+++ b/files/download-artifact-from-artifactory.sh
@@ -2,7 +2,7 @@
 
 # Define Artifactory Configuration
 ARTIFACTORY_BASE=
-URL_BASE=/artifactory
+URL_BASE=
 
 usage()
 {

--- a/manifests/artifact.pp
+++ b/manifests/artifact.pp
@@ -77,17 +77,19 @@ define artifactory::artifact(
   $cmdpart = "${artifactory::installdir}/${artifactory::scriptname} -a ${gav} -e ${packaging} ${includeClass} -n ${artifactory::ARTIFACTORY_URL} ${includeRepo} ${timestampedRepo} -o ${output} ${args} -v"
 
   if $::operatingsystem == 'windows' {
-    Exec { path => ['C:/Windows/System32/WindowsPowerShell/v1.0'], }
-    cmd = "powershell -executionpolicy remotesigned -file ${cmdpart}"
+    Exec { path => ['C:/Windows/System32', 'C:/Windows/System32/WindowsPowerShell/v1.0'], }
+    $cmd       = "powershell -executionpolicy remotesigned -file ${cmdpart}"
+    $unlesscmd = "cmd /c dir ${output}"
   } else {
     Exec { path => ['/bin', '/sbin', '/usr/bin', '/usr/sbin'], }
-    cmd = "${cmdpart}"
+    $cmd       = "${cmdpart}"
+    $unlesscmd = "test -f ${output}"
   }
 
   if $ensure == present {
     exec { "Download ${gav}-${classifier} to ${output}":
       command => $cmd,
-      unless  => "test -f ${output}"
+      unless  => $unlesscmd
     }
   } elsif $ensure == absent {
     file { "Remove ${gav}-${classifier} to ${output}":

--- a/manifests/artifact.pp
+++ b/manifests/artifact.pp
@@ -55,7 +55,6 @@ define artifactory::artifact(
 
   include artifactory
 
-  Exec { path => ['/bin', '/sbin', '/usr/bin', '/usr/sbin'], }
 
   if ($artifactory::authentication) {
     $args = "-u ${artifactory::user} -p '${artifactory::pwd}'"
@@ -75,7 +74,15 @@ define artifactory::artifact(
     $timestampedRepo = "-t"
   }
 
-  $cmd = "/opt/artifactory-script/download-artifact-from-artifactory.sh -a ${gav} -e ${packaging} ${includeClass} -n ${artifactory::ARTIFACTORY_URL} ${includeRepo} ${timestampedRepo} -o ${output} ${args} -v"
+  $cmdpart = "${artifactory::installdir}/${artifactory::scriptname} -a ${gav} -e ${packaging} ${includeClass} -n ${artifactory::ARTIFACTORY_URL} ${includeRepo} ${timestampedRepo} -o ${output} ${args} -v"
+
+  if $::operatingsystem == 'windows' {
+    Exec { path => ['C:/Windows/System32/WindowsPowerShell/v1.0'], }
+    cmd = "powershell -executionpolicy remotesigned -file ${cmdpart}"
+  } else {
+    Exec { path => ['/bin', '/sbin', '/usr/bin', '/usr/sbin'], }
+    cmd = "${cmdpart}"
+  }
 
   if $ensure == present {
     exec { "Download ${gav}-${classifier} to ${output}":

--- a/manifests/artifact.pp
+++ b/manifests/artifact.pp
@@ -74,22 +74,30 @@ define artifactory::artifact(
     $timestampedRepo = "-t"
   }
 
-  $cmdpart = "${artifactory::installdir}/${artifactory::scriptname} -a ${gav} -e ${packaging} ${includeClass} -n ${artifactory::ARTIFACTORY_URL} ${includeRepo} ${timestampedRepo} -o ${output} ${args} -v"
+  $cmdargs = "-a ${gav} -e ${packaging} ${includeClass} -n ${artifactory::ARTIFACTORY_URL} ${includeRepo} ${timestampedRepo} -o ${output} ${args} -v"
 
   if $::operatingsystem == 'windows' {
     Exec { path => ['C:/Windows/System32', 'C:/Windows/System32/WindowsPowerShell/v1.0'], }
-    $cmd       = "powershell -executionpolicy remotesigned -file ${cmdpart}"
-    $unlesscmd = "cmd /c dir ${output}"
+    $downloadcmd = "${artifactory::installdir}\\${artifactory::downloadscript} ${cmdargs}"
+    $comparecmd  = "${artifactory::installdir}\\${artifactory::comparescript}  ${cmdargs}"
+    $cmd         = "powershell -executionpolicy remotesigned -file ${downloadcmd}"
+    $unlesscmd   = "powershell -executionpolicy remotesigned -file ${comparecmd}"
   } else {
     Exec { path => ['/bin', '/sbin', '/usr/bin', '/usr/sbin'], }
-    $cmd       = "${cmdpart}"
-    $unlesscmd = "test -f ${output}"
+    $downloadcmd = "${artifactory::installdir}/${artifactory::downloadscript} ${cmdargs}"
+    $comparecmd  = "${artifactory::installdir}/${artifactory::comparescript}  ${cmdargs}"
+    $cmd         = "${downloadcmd}"
+    $unlesscmd   = "${comparecmd}"
   }
 
   if $ensure == present {
     exec { "Download ${gav}-${classifier} to ${output}":
       command => $cmd,
-      unless  => $unlesscmd
+      unless  => $unlesscmd,
+      require => File [
+          "${artifactory::installdir}/${artifactory::comparescript}",
+          "${artifactory::installdir}/${artifactory::downloadscript}"
+      ],
     }
   } elsif $ensure == absent {
     file { "Remove ${gav}-${classifier} to ${output}":
@@ -99,6 +107,7 @@ define artifactory::artifact(
   } else {
     exec { "Download ${gav}-${classifier} to ${output}":
       command => $cmd,
+      require => File [ "${artifactory::installdir}/${artifactory::downloadscript}" ],
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,16 +42,26 @@ class artifactory(
     $pwd = $password
   }
 
-  # Install script
-  file { '/opt/artifactory-script/download-artifact-from-artifactory.sh':
-    ensure   => file,
-    owner    => 'root',
-    mode     => '0755',
-    source   => 'puppet:///modules/artifactory/download-artifact-from-artifactory.sh',
-    require  => File ['/opt/artifactory-script']
+  if $::operatingsystem == 'windows' {
+    $installdir = 'C:\ProgramData\artifactory-script'
+    $scriptname = 'download-artifact-from-artifactory.ps1'
+
+  } else {
+    $installdir = '/opt/artifactory-script'
+    $scriptname = 'download-artifact-from-artifactory.sh'
   }
 
-  file { '/opt/artifactory-script':
-    ensure => directory
-  }	
+  # Install script
+  file { "${installdir}/${scriptname}":
+    ensure  => file,
+    mode    => '0755',
+    source  => "puppet:///modules/artifactory/${scriptname}",
+    require => File ["${installdir}"]
+  }
+
+
+  file { "${$installdir}":
+    ensure  => directory
+  }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,21 +44,30 @@ class artifactory(
 
   if $::operatingsystem == 'windows' {
     $installdir = 'C:\ProgramData\artifactory-script'
-    $scriptname = 'download-artifact-from-artifactory.ps1'
+    $downloadscript = 'download-artifact-from-artifactory.ps1'
+    $comparescript  = 'compare-artifact-checksums.ps1'
     File { source_permissions => ignore }
   } else {
     $installdir = '/opt/artifactory-script'
-    $scriptname = 'download-artifact-from-artifactory.sh'
+    $downloadscript = 'download-artifact-from-artifactory.sh'
+    $comparescript  = 'compare-artifact-checksums.sh'
   }
 
-  # Install script
-  file { "${installdir}/${scriptname}":
+  # Install download script
+  file { "${installdir}/${downloadscript}":
     ensure  => file,
     mode    => '0755',
-    source  => "puppet:///modules/artifactory/${scriptname}",
+    source  => "puppet:///modules/artifactory/${downloadscript}",
     require => File ["${installdir}"]
   }
 
+  # Install compare script
+  file { "${installdir}/${comparescript}":
+    ensure  => file,
+    mode    => '0755',
+    source  => "puppet:///modules/artifactory/${comparescript}",
+    require => File ["${installdir}"]
+  }
 
   file { "${$installdir}":
     ensure  => directory

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,7 +45,7 @@ class artifactory(
   if $::operatingsystem == 'windows' {
     $installdir = 'C:\ProgramData\artifactory-script'
     $scriptname = 'download-artifact-from-artifactory.ps1'
-
+    File { source_permissions => ignore }
   } else {
     $installdir = '/opt/artifactory-script'
     $scriptname = 'download-artifact-from-artifactory.sh'


### PR DESCRIPTION
This pull request include:
- Improved verification of whether the right file is already present or should be downloaded from Artifactory. If possible, an MD5 checksum of the present file is compared to the MD5 checksum recorded in Artifactory. This is particularly useful for SNAPSHOT artifacts, which may change content without changing version or filename. An additional script (made from a copy of download-artifact-from-artifactory.sh) was introduced for this purpose.
- Windows support is introduced by translating the two shell scripts to powershell. Note that the part about timestamped SNAPSHOTs was not ported (it's not used in our setup => not a priority and not easily tested).
- The module no longer appends '/artifactory' to the URL (an Artifactory installation doesn't necessarily include that part in the URL). If required, then it must be included in the specified URL. This change is not backwards compatible: a user needs to change the specified URL when upgrading this module.

Ideally these changes would be split in different pull requests. I only realised after doing all the changes that I wanted to try to feed the changes back upstream, so now it ended up in a single big pull request (sorry about that).
